### PR TITLE
Add UIUserInterfaceStyle to disable iOS 13 Dark Mode

### DIFF
--- a/iOS/OCRuntime/OCRuntime-Info.plist
+++ b/iOS/OCRuntime/OCRuntime-Info.plist
@@ -55,5 +55,7 @@
 		<string>UIInterfaceOrientationLandscapeRight</string>
 		<string>UIInterfaceOrientationPortraitUpsideDown</string>
 	</array>
+	<key>UIUserInterfaceStyle</key>
+	<string>Light</string>
 </dict>
 </plist>


### PR DESCRIPTION
Disable the iOS 13 Dark Mode in the app due to some weird UI behavior due to it not being updated

![IMG_2975](https://user-images.githubusercontent.com/19736790/74615555-f1103b00-50ef-11ea-927c-111b786fe7d3.PNG)
![IMG_2974](https://user-images.githubusercontent.com/19736790/74615557-f2d9fe80-50ef-11ea-82fc-03a896811af8.PNG)
