### PR TITLE
Adds required entitlement for dumping any classes related to Powerlog

### DIFF
--- a/iOS/entitlements.plist
+++ b/iOS/entitlements.plist
@@ -8,6 +8,10 @@
 	<true/>
 	<key>com.apple.private.security.no-container</key>
 	<true/>
+	<key>com.apple.security.system-groups</key>
+	<array>
+		<string>systemgroup.com.apple.powerlog</string>
+	</array>
 	<key>com.apple.springboard-ui.client</key>
 	<true/>
 </dict>


### PR DESCRIPTION
The app will crash without this when trying to dump the Powerlog*.framework's